### PR TITLE
Add only files generated by continuous analysis 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ build:
     - git remote set-url origin https://github.com/greenelab/gbm_immune_validation
 
     - git checkout master
-    - git add *
+    - git add .
     - git commit -a -m "Drone Build [skip CI] [ci skip]"
     - git remote set-url origin https://gwaygenomics:$$GIT_PUBLISH_KEY@github.com/greenelab/gbm_immune_validation.git
     - git push --set-upstream origin master

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ Rplot*
 data/GBM_clinicalMatrix
 data/HT_HG-U133A
 data/clinical_dataframe.tsv
-results/


### PR DESCRIPTION
Drone `.yml` file previously tried adding all files to the commit - I want to maintain the gitignored files so changing line 12 to only add generated but not ignored files. 

Also, I should not be ignoring file generated and placed in the results folder.

Tagging @brettbj for a potentially useful situation to be aware of - going to merge this minor change and set off the CA run.