### PR TITLE
use ssh auth in drone build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,12 +6,10 @@ build:
     - git config user.email "gregory.way@gmail.com"
     - git config user.name "Greg Way"
     - git config --global push.default simple
-    - git remote set-url origin https://github.com/greenelab/gbm_immune_validation.git
 
     - git checkout master
     - git add .
     - git commit -a -m "Drone Build [skip CI] [ci skip]"
-    - git remote set-url origin https://gwaygenomics:$$git_publish_key@github.com/greenelab/gbm_immune_validation.git
     - git push --set-upstream origin master
 
 branches:


### PR DESCRIPTION
Previously added repo specific drone ssh public key to known hosts - should allow for pushing back